### PR TITLE
Update Ubuntu and GCC versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from docker/ubuntu:16.04
+from ubuntu:16.04
 MAINTAINER David Liu <email4dliu@gmail.com>
 
 LABEL Description="Do your C/C++ development in Docker container. Based on Ubuntu, and added build-essential and valgrind so you can use g++/gcc/gdb/valgrind."

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER David Liu <email4dliu@gmail.com>
 
 LABEL Description="Do your C/C++ development in Docker container. Based on Ubuntu, and added build-essential and valgrind so you can use g++/gcc/gdb/valgrind."
 
+#update package files to ensure newest versions
+run apt-get update
+
 #adds gcc valgrind
 run apt-get install -y build-essential valgrind 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-#use 32-bit ubuntu 12.04 required by valgrind. 64-bit has some known issues
-from shawn/ubuntu-precise-i386
+from docker/ubuntu:16.04
 MAINTAINER David Liu <email4dliu@gmail.com>
 
 LABEL Description="Do your C/C++ development in Docker container. Based on Ubuntu, and added build-essential and valgrind so you can use g++/gcc/gdb/valgrind."
-
 
 #adds gcc valgrind
 run apt-get install -y build-essential valgrind 

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 # To build the image from Dockerfile, use this command:
-#docker build -t="dliu/ubuntu-gcc-valgrind" .
+docker build -t="dliu/ubuntu-gcc-valgrind" .
 


### PR DESCRIPTION
I upgraded the base image to Ubuntu 16.04 (current LTS) to keep up with the latest updates and to enable the use of newer versions of GCC. In particular, the newer versions included with this image support the C++14 standard.